### PR TITLE
Bump typescript from 3.9.3 to 4.4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "ts-jest": "^25.4.0",
     "ts-loader": "^6.2.2",
     "ts-node": "^8.4.1",
-    "typescript": "^3.9.3"
+    "typescript": "^4.4.3"
   },
   "pankod": {
     "projectType": "nextjs2"


### PR DESCRIPTION
### What does this PR do
It bumped `typescript` from 3.9.3 to latest stable 4.4.3

### Bump description
typescript 3.9.3 raises error `TypeError: Cannot read property 'kind' of undefined'` in windows 10
upgrading the typescript version to any version from 4.0 fixes the issue.

### How to manually test this
- checkout to branch `bump-typescript-to-4.4.3`
- run `yarn install` or `npm install`
- run `yarn start:dev ` or `npm run start:dev`

### Expected behavior
- App should be launched on default port 3000 effectively
